### PR TITLE
chore(renovate): preserve semver ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":preserveSemverRanges"
   ]
 }


### PR DESCRIPTION
This change will disable Renovate from attempting to pin dependencies and will instead upgrade ranges if the latest version does not fall within the current range.